### PR TITLE
Use public packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 **/*.iml
 **/.gradle
 **/.env
+**/.env.save
 **/local.properties
 **/captures
 **/.externalNativeBuild

--- a/javascript/.prettierignore
+++ b/javascript/.prettierignore
@@ -1,0 +1,6 @@
+/.idea
+/.vscode
+/dist
+/node_modules
+/coverage
+/package-lock.json

--- a/javascript/demo/polyline-test.html
+++ b/javascript/demo/polyline-test.html
@@ -16,7 +16,7 @@
   <body>
     <div id="map" />
     <script src="https://unpkg.com/maplibre-gl/dist/maplibre-gl.js"></script>
-    <script src="../dist/polyline.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@aws/polyline"></script>
 
     <script>
       // Create a simple map using the default MapLibre demo tiles.

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/polyline",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/polyline",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/polyline",
   "description": "A library for encoding and decoding polylines",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "keywords": [],
   "author": {
     "name": "Amazon Web Services",

--- a/kotlin/app/build.gradle.kts
+++ b/kotlin/app/build.gradle.kts
@@ -42,10 +42,10 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
-    implementation(project(":polyline"))
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
-    implementation("org.maplibre.gl:android-sdk:11.3.0")
+    implementation("org.maplibre.gl:android-sdk:11.5.2")
+    implementation("software.amazon.location:polyline:0.1.0")
 }

--- a/kotlin/polyline/build.gradle.kts
+++ b/kotlin/polyline/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 publishing {
     repositories {
         maven {
-            name = "Polyline"
+            name = "polyline"
             url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
             credentials(PasswordCredentials::class)
         }

--- a/swift/PolylineDemo/PolylineDemo.xcodeproj/project.pbxproj
+++ b/swift/PolylineDemo/PolylineDemo.xcodeproj/project.pbxproj
@@ -7,12 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6817D5942CB9D76F00078BB3 /* Polyline in Frameworks */ = {isa = PBXBuildFile; productRef = 6817D5932CB9D76F00078BB3 /* Polyline */; };
 		6817D5972CB9D79B00078BB3 /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = 6817D5962CB9D79B00078BB3 /* MapLibre */; };
 		685E1E472CAEF07000F2C626 /* PolylineDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685E1E462CAEF07000F2C626 /* PolylineDemoApp.swift */; };
 		685E1E492CAEF07000F2C626 /* SimpleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685E1E482CAEF07000F2C626 /* SimpleMap.swift */; };
 		685E1E4B2CAEF07100F2C626 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 685E1E4A2CAEF07100F2C626 /* Assets.xcassets */; };
 		685E1E4E2CAEF07100F2C626 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 685E1E4D2CAEF07100F2C626 /* Preview Assets.xcassets */; };
+		688CCE352CD18730001D9E4D /* Polyline in Frameworks */ = {isa = PBXBuildFile; productRef = 688CCE342CD18730001D9E4D /* Polyline */; };
 		68AE0BB32CB894B600AF75CF /* Polyline in Frameworks */ = {isa = PBXBuildFile; productRef = 68AE0BB22CB894B600AF75CF /* Polyline */; };
 		68AE0BB62CB968FE00AF75CF /* Polyline in Frameworks */ = {isa = PBXBuildFile; productRef = 68AE0BB52CB968FE00AF75CF /* Polyline */; };
 		68AE0BB92CB9695100AF75CF /* Polyline in Frameworks */ = {isa = PBXBuildFile; productRef = 68AE0BB82CB9695100AF75CF /* Polyline */; };
@@ -35,7 +35,7 @@
 				6817D5972CB9D79B00078BB3 /* MapLibre in Frameworks */,
 				68AE0BB32CB894B600AF75CF /* Polyline in Frameworks */,
 				68AE0BB62CB968FE00AF75CF /* Polyline in Frameworks */,
-				6817D5942CB9D76F00078BB3 /* Polyline in Frameworks */,
+				688CCE352CD18730001D9E4D /* Polyline in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,8 +97,8 @@
 				68AE0BB22CB894B600AF75CF /* Polyline */,
 				68AE0BB52CB968FE00AF75CF /* Polyline */,
 				68AE0BB82CB9695100AF75CF /* Polyline */,
-				6817D5932CB9D76F00078BB3 /* Polyline */,
 				6817D5962CB9D79B00078BB3 /* MapLibre */,
+				688CCE342CD18730001D9E4D /* Polyline */,
 			);
 			productName = PolylineDemo;
 			productReference = 685E1E432CAEF07000F2C626 /* PolylineDemo.app */;
@@ -129,8 +129,8 @@
 			);
 			mainGroup = 685E1E3A2CAEF07000F2C626;
 			packageReferences = (
-				6817D5922CB9D76E00078BB3 /* XCRemoteSwiftPackageReference "polyline" */,
 				6817D5952CB9D79B00078BB3 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
+				688CCE332CD18730001D9E4D /* XCRemoteSwiftPackageReference "polyline" */,
 			);
 			productRefGroup = 685E1E442CAEF07000F2C626 /* Products */;
 			projectDirPath = "";
@@ -367,14 +367,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		6817D5922CB9D76E00078BB3 /* XCRemoteSwiftPackageReference "polyline" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/aws-geospatial/polyline";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
-			};
-		};
 		6817D5952CB9D79B00078BB3 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
@@ -383,18 +375,26 @@
 				minimumVersion = 6.7.1;
 			};
 		};
+		688CCE332CD18730001D9E4D /* XCRemoteSwiftPackageReference "polyline" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/aws-geospatial/polyline";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		6817D5932CB9D76F00078BB3 /* Polyline */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6817D5922CB9D76E00078BB3 /* XCRemoteSwiftPackageReference "polyline" */;
-			productName = Polyline;
-		};
 		6817D5962CB9D79B00078BB3 /* MapLibre */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6817D5952CB9D79B00078BB3 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
 			productName = MapLibre;
+		};
+		688CCE342CD18730001D9E4D /* Polyline */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 688CCE332CD18730001D9E4D /* XCRemoteSwiftPackageReference "polyline" */;
+			productName = Polyline;
 		};
 		68AE0BB22CB894B600AF75CF /* Polyline */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
_Description of changes:_

This changes the polyline demo apps to use the released versions of the polyline package. It also fixes up .prettierconfig to ignore generated files, adds a .gitignore line to ignore temp files, and bumps the version for whenever we make another release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
