### PR TITLE
Added severity and impact fields to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -12,6 +12,7 @@ body:
       description: What is the problem? A clear and concise description of the bug.
     validations:
       required: true
+
   - type: textarea
     id: expected
     attributes:
@@ -20,6 +21,7 @@ body:
         What did you expect to happen?
     validations:
       required: true
+
   - type: textarea
     id: current
     attributes:
@@ -31,6 +33,35 @@ body:
         If service responses are relevant, please include wire logs.
     validations:
       required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Technical Severity
+      description: How serious is this issue from a technical perspective?
+      options:
+        - S1 - Critical (System crash, data loss, security vulnerability)
+        - S2 - Major (Significant functional failure, severe performance issue)
+        - S3 - Moderate (Partial feature malfunction, UI/UX problems)
+        - S4 - Minor (Cosmetic issues, typos, non-critical bugs)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: User Impact
+      description: How many users are affected by this issue?
+      options:
+        - All users
+        - Most users (>50%)
+        - Many users (25-50%)
+        - Some users (5-25%)
+        - Few users (<5%)
+        - Single user/edge case
+    validations:
+      required: true
+
   - type: textarea
     id: reproduction
     attributes:
@@ -43,6 +74,7 @@ body:
         The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
     validations:
       required: true
+
   - type: textarea
     id: solution
     attributes:
@@ -51,6 +83,7 @@ body:
         Suggest a fix/reason for the bug
     validations:
       required: false
+
   - type: textarea
     id: context
     attributes:
@@ -59,6 +92,7 @@ body:
         Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful in the real world.
     validations:
       required: false
+
   - type: input
     id: environment
     attributes:


### PR DESCRIPTION
### Description
Added dropdown fields to the issue template for reporting user to input both:
* Technical Severity - How serious is this issue?
* Impact - How many users are affected by this issue?