### PR TITLE
fix(github): reduced workflow permission scope

### DIFF
--- a/.github/workflows/build-javascript.yml
+++ b/.github/workflows/build-javascript.yml
@@ -18,6 +18,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/build-kotlin.yml
+++ b/.github/workflows/build-kotlin.yml
@@ -18,6 +18,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -14,6 +14,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
_Issue #, if available:_

Address code scan results

_Description of changes:_

Reduces workflow permissions to read only to allow test builds.  It doesn't appear that any of the workflow write or publish their contents back to the repo so this be sufficient without breaking the workflows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
